### PR TITLE
Make gem compatible with new algolia API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mystery_shopper (0.1.6)
+    mystery_shopper (0.1.7)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mystery_shopper (0.1.7)
+    mystery_shopper (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/mystery_shopper.rb
+++ b/lib/mystery_shopper.rb
@@ -1,8 +1,16 @@
 require 'mystery_shopper/version'
+require 'mystery_shopper/configuration'
 require 'mystery_shopper/response'
 require 'mystery_shopper/request/detail'
 require 'mystery_shopper/request/price'
 
 module MysteryShopper
-  # Nothing to see here.
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration)
+  end
 end

--- a/lib/mystery_shopper/configuration.rb
+++ b/lib/mystery_shopper/configuration.rb
@@ -1,0 +1,10 @@
+module MysteryShopper
+  class Configuration
+    attr_accessor :application_id, :api_key
+
+    def initialize
+      @application_id = nil
+      @api_key        = nil
+    end
+  end
+end

--- a/lib/mystery_shopper/game.rb
+++ b/lib/mystery_shopper/game.rb
@@ -8,52 +8,97 @@ module MysteryShopper
       @data = data
     end
 
-    def categories
-      @categories ||= data.fetch('categories')
-    end
-
     def url
       @url ||= "#{base_url}#{data.fetch('url')}"
-    end
-
-    def release_date
-      @release_date ||= Date.parse(data.fetch('releaseDateMask'))
-    end
-
-    def free_to_start?
-      @free_to_start ||= data.fetch('freeToStart')
     end
 
     def title
       @title ||= data.fetch('title')
     end
 
-    def slug
-      @slug ||= data.fetch('slug')
-    end
-
-    def platform
-      @platform ||= data.fetch('platform')
+    def description
+      @description ||= data.fetch('description')
     end
 
     def id
       @id ||= data.fetch('id')
     end
 
-    def number_of_players
-      @number_of_players ||= data.fetch('players')
-    end
-
     def nsuid
       @nsuid ||= data['nsuid']
+    end
+
+    def slug
+      @slug ||= data.fetch('slug')
     end
 
     def front_box_art
       @front_box_art ||= "#{base_url}#{data.fetch('boxArt')}"
     end
 
-    def buy_online?
-      @buy_online ||= data.fetch('buyonline')
+    # TODO: Figure out what the value  returned here actually is.
+    def gallery
+      @gallery ||= data.fetch('gallery')
+    end
+
+    def platform
+      @platform ||= data.fetch('platform')
+    end
+
+    def release_date
+      @release_date ||= Date.parse(data.fetch('releaseDateMask'))
+    end
+
+    def characters
+      @characters ||= data.fetch('characters')
+    end
+
+    def categories
+      @categories ||= data.fetch('categories')
+    end
+
+    def esrb
+      @esrb ||= data.fetch('esrb')
+    end
+
+    def esrb_descriptors
+      @esrb_descriptors ||= data.fetch('esrbDescriptors')
+    end
+
+    def virtual_console
+      @virtual_console ||= data.fetch('virtualConsole')
+    end
+
+    def general_filters
+      @general_filters ||= data.fetch('generalFilters')
+    end
+
+    def filter_shops
+      @filter_shops ||= data.fetch('filterShops')
+    end
+
+    def filter_players
+      @filter_players ||= data.fetch('filterPlayers')
+    end
+
+    def number_of_players
+      @number_of_players ||= data.fetch('players')
+    end
+
+    def featured?
+      @featured ||= data.fetch('featured')
+    end
+
+    def free_to_start?
+      @free_to_start ||= data.fetch('freeToStart')
+    end
+
+    def price_range
+      @price_range ||= data.fetch('priceRange')
+    end
+
+    def availability
+      @availability ||= data.fetch('availability')
     end
 
     def regular_price

--- a/lib/mystery_shopper/game.rb
+++ b/lib/mystery_shopper/game.rb
@@ -1,38 +1,27 @@
 require 'date'
-require 'mystery_shopper/utils'
 require 'mystery_shopper/price'
 require 'mystery_shopper/request/price'
 
 module MysteryShopper
   class Game
-    include Utils
-
     def initialize(data)
       @data = data
     end
 
     def categories
-      @categories ||= Array(data.dig('categories', 'category'))
+      @categories ||= data.fetch('categories')
     end
 
     def url
-      @url ||= "https://www.nintendo.com/games/detail/#{slug}"
-    end
-
-    def buy_it_now?
-      @buy_it_now ||= to_bool(data.fetch('buyitnow'))
+      @url ||= "#{base_url}#{data.fetch('url')}"
     end
 
     def release_date
-      @release_date ||= Date.parse(data.fetch('release_date'))
-    end
-
-    def digital_download?
-      @digital_download ||= to_bool(data.fetch('digitaldownload'))
+      @release_date ||= Date.parse(data.fetch('releaseDateMask'))
     end
 
     def free_to_start?
-      @free_to_start ||= to_bool(data.fetch('free_to_start'))
+      @free_to_start ||= data.fetch('freeToStart')
     end
 
     def title
@@ -43,8 +32,8 @@ module MysteryShopper
       @slug ||= data.fetch('slug')
     end
 
-    def system
-      @system ||= data.fetch('system')
+    def platform
+      @platform ||= data.fetch('platform')
     end
 
     def id
@@ -52,27 +41,19 @@ module MysteryShopper
     end
 
     def number_of_players
-      @number_of_players ||= data.fetch('number_of_players')
+      @number_of_players ||= data.fetch('players')
     end
 
     def nsuid
       @nsuid ||= data['nsuid']
     end
 
-    def video_link
-      @video_link ||= data['video_link']
-    end
-
     def front_box_art
-      @front_box_art ||= data.fetch('front_box_art')
-    end
-
-    def game_code
-      @game_code ||= data.fetch('game_code')
+      @front_box_art ||= "#{base_url}#{data.fetch('boxArt')}"
     end
 
     def buy_online?
-      @buy_online ||= to_bool(data.fetch('buyonline'))
+      @buy_online ||= data.fetch('buyonline')
     end
 
     def regular_price
@@ -103,6 +84,10 @@ module MysteryShopper
       @price_details ||= Price.new(
         Request::Price.new(nsuid).get.fetch('prices').first
       )
+    end
+
+    def base_url
+      'https://www.nintendo.com'
     end
   end
 end

--- a/lib/mystery_shopper/request/base.rb
+++ b/lib/mystery_shopper/request/base.rb
@@ -9,12 +9,25 @@ module MysteryShopper
         JSON.parse(Net::HTTP.get(construct_uri))
       end
 
+      def post
+        JSON.parse(Net::HTTP.new(uri.host).request(construct_request).body)
+      end
+
       private
 
-      def construct_uri
-        URI(uri).tap do |uri|
-          uri.query = URI.encode_www_form(params)
+      def construct_request
+        Net::HTTP::Post.new(construct_uri).tap do |request|
+          request.body = body.to_json
         end
+      end
+
+      def construct_uri
+        uri.query = URI.encode_www_form(params)
+      end
+
+      def params
+        { 'x-algolia-application-id' => application_id,
+          'x-algolia-api-key' => api_key }
       end
     end
   end

--- a/lib/mystery_shopper/request/base.rb
+++ b/lib/mystery_shopper/request/base.rb
@@ -10,7 +10,7 @@ module MysteryShopper
       end
 
       def post
-        JSON.parse(Net::HTTP.new(uri.host).request(construct_request).body)
+        JSON.parse(Net::HTTP.new(construct_uri.host).request(construct_request).body)
       end
 
       private
@@ -22,7 +22,9 @@ module MysteryShopper
       end
 
       def construct_uri
-        uri.query = URI.encode_www_form(params)
+        URI.parse(uri).tap do |uri|
+          uri.query = URI.encode_www_form(params)
+        end
       end
 
       def params

--- a/lib/mystery_shopper/request/detail.rb
+++ b/lib/mystery_shopper/request/detail.rb
@@ -14,27 +14,26 @@ module MysteryShopper
       attr_reader :application_id, :api_key, :options
 
       def uri
-        URI("https://#{application_id}-dsn.algolia.net/1/indexes/*/queries")
+        "https://#{application_id}-dsn.algolia.net/1/indexes/*/queries"
       end
 
       def body
         {
-          'requests' => [
+          requests: [
             {
-              'indexName' => sort_direction,
-              'params' => "query=&#{request_params}"
+              indexName: sort_direction,
+              params: request_params
             }
           ]
         }
       end
 
       def request_params
-        { hitsPerPage: defaults[:limit],
-          page: defaults[:page],
-          facets: facets,
-          facetFilters: facet_filters }.map do |key, value|
-            "#{key}=#{value}"
-          end.join('&')
+        'query='\
+        "&hitsPerPage=#{defaults[:limit]}"\
+        "&page=#{defaults[:page]}"\
+        "&facets=#{facets}"\
+        "&facetFilters=#{facet_filters}"
       end
 
       def facets
@@ -69,9 +68,10 @@ module MysteryShopper
       end
 
       def sort_direction
-        return ['noa_aem_game_en_us'] if defaults[:sort] == 'featured'
+        base = 'noa_aem_game_en_us'
+        return base if defaults[:sort] == 'featured'
 
-        ['noa_aem_game_en_us_',
+        [base,
          defaults[:sort],
          defaults[:direction]].join('_')
       end

--- a/lib/mystery_shopper/request/detail.rb
+++ b/lib/mystery_shopper/request/detail.rb
@@ -60,11 +60,9 @@ module MysteryShopper
       end
 
       def availability
-        [
-          defaults[:availability].map do |avail|
-            "availability:#{mappings.dig(:availability, avail)}"
-          end.join(', ')
-        ]
+        defaults[:availability].map do |avail|
+          "availability:#{mappings.dig(:availability, avail)}"
+        end
       end
 
       def sort_direction

--- a/lib/mystery_shopper/request/detail.rb
+++ b/lib/mystery_shopper/request/detail.rb
@@ -4,24 +4,93 @@ module MysteryShopper
   module Request
     class Detail < Base
       def initialize(**options)
-        @options = options
+        @application_id = MysteryShopper.configuration.application_id
+        @api_key        = MysteryShopper.configuration.api_key
+        @options        = options
       end
 
       private
 
-      attr_reader :options
+      attr_reader :application_id, :api_key, :options
 
       def uri
-        'https://www.nintendo.com/json/content/get/filter/game'
+        URI("https://#{application_id}-dsn.algolia.net/1/indexes/*/queries")
       end
 
-      def params
+      def body
+        {
+          'requests' => [
+            {
+              'indexName' => sort_direction,
+              'params' => "query=&#{request_params}"
+            }
+          ]
+        }
+      end
+
+      def request_params
+        { hitsPerPage: defaults[:limit],
+          page: defaults[:page],
+          facets: facets,
+          facetFilters: facet_filters }.map do |key, value|
+            "#{key}=#{value}"
+          end.join('&')
+      end
+
+      def facets
+        %w[generalFilters
+           platform
+           availability]
+      end
+
+      def facet_filters
+        [general_filters,
+         platform,
+         availability].compact
+      end
+
+      def general_filters
+        return unless defaults[:sale]
+
+        ['generalFilters:Deals']
+      end
+
+      # TODO: Support 3DS, Wii U, iOS, Android platforms
+      def platform
+        ['platform:Nintendo Switch']
+      end
+
+      def availability
+        [
+          defaults[:availability].map do |avail|
+            "availability:#{mappings.dig(:availability, avail)}"
+          end.join(', ')
+        ]
+      end
+
+      def sort_direction
+        return ['noa_aem_game_en_us'] if defaults[:sort] == 'featured'
+
+        ['noa_aem_game_en_us_',
+         defaults[:sort],
+         defaults[:direction]].join('_')
+      end
+
+      def defaults
         { limit: 50,
-          offset: 0,
+          page: 0,
           availability: 'now',
           sort: 'title',
           direction: 'asc',
           system: 'switch' }.merge(options)
+      end
+
+      def mappings
+        { availability: {
+          'now' => 'Available now',
+          'prepurchase' => 'Pre-purchase',
+          'soon' => 'Coming soon'
+        } }
       end
     end
   end

--- a/lib/mystery_shopper/request/price.rb
+++ b/lib/mystery_shopper/request/price.rb
@@ -13,7 +13,7 @@ module MysteryShopper
       attr_reader :ids, :options
 
       def uri
-        URI('https://api.ec.nintendo.com/v1/price')
+        'https://api.ec.nintendo.com/v1/price'
       end
 
       def params

--- a/lib/mystery_shopper/request/price.rb
+++ b/lib/mystery_shopper/request/price.rb
@@ -13,7 +13,7 @@ module MysteryShopper
       attr_reader :ids, :options
 
       def uri
-        'https://api.ec.nintendo.com/v1/price'
+        URI('https://api.ec.nintendo.com/v1/price')
       end
 
       def params

--- a/lib/mystery_shopper/response.rb
+++ b/lib/mystery_shopper/response.rb
@@ -7,7 +7,7 @@ module MysteryShopper
     end
 
     def games
-      data.fetch('games', []).fetch('game', []).map { |game| Game.new(game) }
+      data.dig('results', 0, 'hits').map { |game| Game.new(game) }
     end
 
     private

--- a/lib/mystery_shopper/utils.rb
+++ b/lib/mystery_shopper/utils.rb
@@ -1,7 +1,0 @@
-module MysteryShopper
-  module Utils
-    def to_bool(str)
-      str == 'true'
-    end
-  end
-end

--- a/lib/mystery_shopper/version.rb
+++ b/lib/mystery_shopper/version.rb
@@ -1,3 +1,3 @@
 module MysteryShopper
-  VERSION = '0.1.7'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/mystery_shopper.gemspec
+++ b/mystery_shopper.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.8'
   spec.add_development_dependency 'rubocop', '~> 0.58'
 end

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe MysteryShopper::Game do
       'gallery' => '1nNjVtaDE6yijrWKfJL5ebXMPSh-mlaS',
       'platform' => 'Nintendo Switch',
       'releaseDateMask' => '2018-08-06T00:00:00.000-07:00',
-      'characters' => [],
+      'characters' => ['Mario'],
       'categories' => %w[Strategy Party Simulation],
       'msrp' => 24.99,
       'salePrice' => 18.74,
@@ -60,21 +60,136 @@ RSpec.describe MysteryShopper::Game do
     )
   end
 
-  describe '#categories' do
-    it 'returns an array of categories' do
-      expect(subject.categories).to eq %w[Strategy Party Simulation]
-    end
-  end
-
   describe '#url' do
     it 'returns the correct URL' do
       expect(subject.url).to eq 'https://www.nintendo.com/games/detail/overcooked-2-switch'
     end
   end
 
+  describe '#title' do
+    it 'returns the game title' do
+      expect(subject.title).to eq 'Overcooked! 2'
+    end
+  end
+
+  describe '#description' do
+    it 'returns the game description' do
+      expect(subject.description).to eq 'Sample description.'
+    end
+  end
+
+  describe '#id' do
+    it 'returns the game ID' do
+      expect(subject.id).to eq 'bMo0R6zC5D5ewf5wTc424zc7RQnDFSIp'
+    end
+  end
+
+  describe '#nsuid' do
+    it 'returns the game NSUID' do
+      expect(subject.nsuid).to eq '70010000003402'
+    end
+  end
+
+  describe '#slug' do
+    it 'returns the game slug' do
+      expect(subject.slug).to eq 'overcooked-2-switch'
+    end
+  end
+
+  describe '#front_box_art' do
+    it 'returns the URL of the game box art' do
+      expect(subject.front_box_art).to eq 'https://www.nintendo.com/content/dam/noa/en_US/games/switch/o/overcooked-2-switch/Switch_Overcooked2_box.png'
+    end
+  end
+
+  describe '#gallery' do
+    it 'returns the gallery' do
+      expect(subject.gallery).to eq '1nNjVtaDE6yijrWKfJL5ebXMPSh-mlaS'
+    end
+  end
+
+  describe '#platform' do
+    it 'returns the game platform' do
+      expect(subject.platform).to eq 'Nintendo Switch'
+    end
+  end
+
   describe '#release_date' do
     it 'returns the correct Date object' do
       expect(subject.release_date).to eq Date.new(2018, 8, 6)
+    end
+  end
+
+  describe '#characters' do
+    it 'returns an array of characters' do
+      expect(subject.characters).to eq %w[Mario]
+    end
+  end
+
+  describe '#categories' do
+    it 'returns an array of categories' do
+      expect(subject.categories).to eq %w[Strategy Party Simulation]
+    end
+  end
+
+  describe '#esrb' do
+    it 'returns the ESRB rating' do
+      expect(subject.esrb).to eq 'Everyone'
+    end
+  end
+
+  describe '#esrb_descriptors' do
+    it 'returns an array of ESRB descriptors' do
+      expect(subject.esrb_descriptors).to eq ['Users Interact']
+    end
+  end
+
+  # This appears to be "na" for every result right now.
+  describe '#virtual_console' do
+    it 'returns "na"' do
+      expect(subject.virtual_console).to eq 'na'
+    end
+  end
+
+  describe '#general_filters' do
+    it 'returns an array of general filters that match the game' do
+      expect(subject.general_filters).to eq ['DLC available', 'Online Play via Nintendo Switch Online', 'Deals']
+    end
+  end
+
+  describe '#filter_shops' do
+    it 'returns an array of shop filters that match the game' do
+      expect(subject.filter_shops).to eq ['At retail', 'On Nintendo.com']
+    end
+  end
+
+  describe '#filter_players' do
+    it 'returns an array of player filters that match the game' do
+      expect(subject.filter_players).to eq ['3+', '2+', '1+']
+    end
+  end
+
+  describe '#number_of_players' do
+    it 'returns the number of players for the game' do
+      expect(subject.number_of_players).to eq 'up to 4 players'
+    end
+  end
+
+  describe '#featured?' do
+    context 'when it is true' do
+      it 'returns true' do
+        expect(subject.featured?).to be true
+      end
+    end
+
+    context 'when it is false' do
+      before do
+        data['featured'] = false
+      end
+
+      it 'returns false' do
+        expect(subject.featured?).to be false
+      end
     end
   end
 
@@ -96,45 +211,15 @@ RSpec.describe MysteryShopper::Game do
     end
   end
 
-  describe '#title' do
-    it 'returns the game title' do
-      expect(subject.title).to eq 'Overcooked! 2'
+  describe '#price_range' do
+    it 'returns the price range of the game' do
+      expect(subject.price_range).to eq '$10 - $19.99'
     end
   end
 
-  describe '#slug' do
-    it 'returns the game slug' do
-      expect(subject.slug).to eq 'overcooked-2-switch'
-    end
-  end
-
-  describe '#platform' do
-    it 'returns the game platform' do
-      expect(subject.platform).to eq 'Nintendo Switch'
-    end
-  end
-
-  describe '#id' do
-    it 'returns the game ID' do
-      expect(subject.id).to eq 'bMo0R6zC5D5ewf5wTc424zc7RQnDFSIp'
-    end
-  end
-
-  describe '#number_of_players' do
-    it 'returns the number of players for the game' do
-      expect(subject.number_of_players).to eq 'up to 4 players'
-    end
-  end
-
-  describe '#nsuid' do
-    it 'returns the game NSUID' do
-      expect(subject.nsuid).to eq '70010000003402'
-    end
-  end
-
-  describe '#front_box_art' do
-    it 'returns the URL of the game box art' do
-      expect(subject.front_box_art).to eq 'https://www.nintendo.com/content/dam/noa/en_US/games/switch/o/overcooked-2-switch/Switch_Overcooked2_box.png'
+  describe '#availability' do
+    it 'returns an array of availability statuses' do
+      expect(subject.availability).to eq ['Available now']
     end
   end
 

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -79,9 +79,9 @@ RSpec.describe MysteryShopper::Game do
   end
 
   describe '#free_to_start?' do
-    context 'when it is "true"' do
+    context 'when it is true' do
       before do
-        data['freeToStart'] = 'true'
+        data['freeToStart'] = true
       end
 
       it 'returns true' do
@@ -89,7 +89,7 @@ RSpec.describe MysteryShopper::Game do
       end
     end
 
-    context 'when it is "false"' do
+    context 'when it is false' do
       it 'returns false' do
         expect(subject.free_to_start?).to be false
       end

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -7,30 +7,42 @@ RSpec.describe MysteryShopper::Game do
 
   let(:data) do
     {
-      'categories' => { 'category' => %w[Arcade Multiplayer Party Puzzle] },
-      'slug' => 'breakforcist-battle-switch',
-      'buyitnow' => 'false',
-      'release_date' => 'Apr 12, 2018',
-      'digitaldownload' => 'false',
-      'nso' => 'false',
-      'free_to_start' => 'false',
-      'title' => '#Breakforcist Battle',
-      'system' => 'Nintendo Switch',
-      'id' => 'oNfMa9bCbSistTheDdqCtqZ3Lwk_WBw8',
-      'ca_price' => '12.99',
-      'number_of_players' => 'up to 4 players',
-      'nsuid' => '70010000003782',
-      'eshop_price' => '9.99',
-      'front_box_art' => 'https://media.nintendo.com/nintendo/bin/S9233-zQTduo1uWckvUcVqikBSFMUzxZ/7hWl7WrFj-twgIgF1fB6a8Y74qMEGm59.png',
-      'game_code' => 'HACNAK98A',
-      'buyonline' => 'true'
+      'type' => 'game',
+      'locale' => 'en_US',
+      'url' => '/games/detail/overcooked-2-switch',
+      'title' => 'Overcooked! 2',
+      'description' => 'Sample description.',
+      'lastModified' => 1555628882577,
+      'id' => 'bMo0R6zC5D5ewf5wTc424zc7RQnDFSIp',
+      'nsuid' => '70010000003402',
+      'slug' => 'overcooked-2-switch',
+      'boxArt' => '/content/dam/noa/en_US/games/switch/o/overcooked-2-switch/Switch_Overcooked2_box.png',
+      'gallery' => '1nNjVtaDE6yijrWKfJL5ebXMPSh-mlaS',
+      'platform' => 'Nintendo Switch',
+      'releaseDateMask' => '2018-08-06T00:00:00.000-07:00',
+      'characters' => [],
+      'categories' => %w[Strategy Party Simulation],
+      'msrp' => 24.99,
+      'salePrice' => 18.74,
+      'esrb' => 'Everyone',
+      'esrbDescriptors' => ['Users Interact'],
+      'virtualConsole' => 'na',
+      'generalFilters' => ['DLC available', 'Online Play via Nintendo Switch Online', 'Deals'],
+      'filterShops' => ['At retail', 'On Nintendo.com'],
+      'filterPlayers' => ['3+', '2+', '1+'],
+      'players' => 'up to 4 players',
+      'featured' => true,
+      'freeToStart' => false,
+      'priceRange' => '$10 - $19.99',
+      'availability' => ['Available now'],
+      'objectID' => '85d4db29-0a15-3924-a43b-7302d15d9f5f'
     }
   end
 
   before do
     allow(subject).to receive(:price_details).and_return(
       MysteryShopper::Price.new(
-        'title_id' => 70010000003782,
+        'title_id' => 70_010_000_003_782,
         'sales_status' => 'onsale',
         'regular_price' => {
           'amount' => '$9.99',
@@ -49,75 +61,27 @@ RSpec.describe MysteryShopper::Game do
   end
 
   describe '#categories' do
-    context 'when there is only one category' do
-      before do
-        data['categories']['category'] = 'Arcade'
-      end
-
-      it 'returns an array of categories' do
-        expect(subject.categories).to eq ['Arcade']
-      end
-    end
-
-    context 'when there are multiple categories' do
-      it 'returns an array of categories' do
-        expect(subject.categories).to eq %w[Arcade Multiplayer Party Puzzle]
-      end
+    it 'returns an array of categories' do
+      expect(subject.categories).to eq %w[Strategy Party Simulation]
     end
   end
 
   describe '#url' do
     it 'returns the correct URL' do
-      expect(subject.url).to eq 'https://www.nintendo.com/games/detail/breakforcist-battle-switch'
-    end
-  end
-
-  describe '#buy_it_now?' do
-    context 'when it is "true"' do
-      before do
-        data['buyitnow'] = 'true'
-      end
-
-      it 'returns true' do
-        expect(subject.buy_it_now?).to be true
-      end
-    end
-
-    context 'when it is "false"' do
-      it 'returns false' do
-        expect(subject.buy_it_now?).to be false
-      end
+      expect(subject.url).to eq 'https://www.nintendo.com/games/detail/overcooked-2-switch'
     end
   end
 
   describe '#release_date' do
     it 'returns the correct Date object' do
-      expect(subject.release_date).to eq Date.new(2018, 4, 12)
-    end
-  end
-
-  describe '#digital_download?' do
-    context 'when it is "true"' do
-      before do
-        data['digitaldownload'] = 'true'
-      end
-
-      it 'returns true' do
-        expect(subject.digital_download?).to be true
-      end
-    end
-
-    context 'when it is "false"' do
-      it 'returns false' do
-        expect(subject.digital_download?).to be false
-      end
+      expect(subject.release_date).to eq Date.new(2018, 8, 6)
     end
   end
 
   describe '#free_to_start?' do
     context 'when it is "true"' do
       before do
-        data['free_to_start'] = 'true'
+        data['freeToStart'] = 'true'
       end
 
       it 'returns true' do
@@ -134,25 +98,25 @@ RSpec.describe MysteryShopper::Game do
 
   describe '#title' do
     it 'returns the game title' do
-      expect(subject.title).to eq '#Breakforcist Battle'
+      expect(subject.title).to eq 'Overcooked! 2'
     end
   end
 
   describe '#slug' do
     it 'returns the game slug' do
-      expect(subject.slug).to eq 'breakforcist-battle-switch'
+      expect(subject.slug).to eq 'overcooked-2-switch'
     end
   end
 
-  describe '#system' do
-    it 'returns the game system' do
-      expect(subject.system).to eq 'Nintendo Switch'
+  describe '#platform' do
+    it 'returns the game platform' do
+      expect(subject.platform).to eq 'Nintendo Switch'
     end
   end
 
   describe '#id' do
     it 'returns the game ID' do
-      expect(subject.id).to eq 'oNfMa9bCbSistTheDdqCtqZ3Lwk_WBw8'
+      expect(subject.id).to eq 'bMo0R6zC5D5ewf5wTc424zc7RQnDFSIp'
     end
   end
 
@@ -164,55 +128,13 @@ RSpec.describe MysteryShopper::Game do
 
   describe '#nsuid' do
     it 'returns the game NSUID' do
-      expect(subject.nsuid).to eq '70010000003782'
-    end
-  end
-
-  describe '#video_link' do
-    context 'when the video link is present' do
-      before do
-        data['video_link'] = '82azBzZzE6_Yl-SGf4PVOtshsLwPpD1H'
-      end
-
-      it 'returns the game video link' do
-        expect(subject.video_link).to eq '82azBzZzE6_Yl-SGf4PVOtshsLwPpD1H'
-      end
-    end
-
-    context 'when the video link is missing' do
-      it 'returns nil' do
-        expect(subject.video_link).to be nil
-      end
+      expect(subject.nsuid).to eq '70010000003402'
     end
   end
 
   describe '#front_box_art' do
     it 'returns the URL of the game box art' do
-      expect(subject.front_box_art).to eq 'https://media.nintendo.com/nintendo/bin/S9233-zQTduo1uWckvUcVqikBSFMUzxZ/7hWl7WrFj-twgIgF1fB6a8Y74qMEGm59.png'
-    end
-  end
-
-  describe '#game_code' do
-    it 'returns the game game code' do
-      expect(subject.game_code).to eq 'HACNAK98A'
-    end
-  end
-
-  describe '#buy_online?' do
-    context 'when it is "true"' do
-      it 'returns true' do
-        expect(subject.buy_online?).to be true
-      end
-    end
-
-    context 'when it is "false"' do
-      before do
-        data['buyonline'] = 'false'
-      end
-
-      it 'returns false' do
-        expect(subject.buy_online?).to be false
-      end
+      expect(subject.front_box_art).to eq 'https://www.nintendo.com/content/dam/noa/en_US/games/switch/o/overcooked-2-switch/Switch_Overcooked2_box.png'
     end
   end
 

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'mystery_shopper/response'
+
+RSpec.describe MysteryShopper::Response do
+  subject { described_class.new(data) }
+
+  let(:data) do
+    {
+      'results' => [
+        { 'hits' => [
+          {
+            'type' => 'game',
+            'locale' => 'en_US',
+            'url' => '/games/detail/overcooked-2-switch',
+            'title' => 'Overcooked! 2',
+            'description' => 'Sample description.',
+            'lastModified' => 1555628882_577,
+            'id' => 'bMo0R6zC5D5ewf5wTc424zc7RQnDFSIp',
+            'nsuid' => '70010000003402',
+            'slug' => 'overcooked-2-switch',
+            'boxArt' => '/content/dam/noa/en_US/games/switch/o/overcooked-2-switch/Switch_Overcooked2_box.png',
+            'gallery' => '1nNjVtaDE6yijrWKfJL5ebXMPSh-mlaS',
+            'platform' => 'Nintendo Switch',
+            'releaseDateMask' => '2018-08-06T00:00:00.000-07:00',
+            'characters' => [],
+            'categories' => %w[Strategy Party Simulation],
+            'msrp' => 24.99,
+            'salePrice' => 18.74,
+            'esrb' => 'Everyone',
+            'esrbDescriptors' => ['Users Interact'],
+            'virtualConsole' => 'na',
+            'generalFilters' => ['DLC available', 'Online Play via Nintendo Switch Online', 'Deals'],
+            'filterShops' => ['At retail', 'On Nintendo.com'],
+            'filterPlayers' => ['3+', '2+', '1+'],
+            'players' => 'up to 4 players',
+            'featured' => true,
+            'freeToStart' => false,
+            'priceRange' => '$10 - $19.99',
+            'availability' => ['Available now'],
+            'objectID' => '85d4db29-0a15-3924-a43b-7302d15d9f5f'
+          }
+        ] }
+      ]
+    }
+  end
+
+  describe '#games' do
+    it 'returns an array of Game objects' do
+      expect(subject.games.size).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
Nintendo made some big changes to their API, which broke version `0.1.0` completely. This makes the necessary changes to work with the new API while remaining backwards compatible.